### PR TITLE
tmpfiles etc.conf and stateless.bbclass reverse mv and rm order

### DIFF
--- a/meta-ostro/classes/stateless.bbclass
+++ b/meta-ostro/classes/stateless.bbclass
@@ -15,6 +15,16 @@ def stateless_mangle(d, root, docdir, stateless_mv, stateless_rm, dirwhitelist, 
     import errno
     import shutil
 
+    # Remove content that is no longer needed.
+    for entry in stateless_rm:
+        old = os.path.join(root, 'etc', entry)
+        if os.path.exists(old) or os.path.islink(old):
+            bb.note('stateless: removing %s' % old)
+            if os.path.isdir(old) and not os.path.islink(old):
+                shutil.rmtree(old)
+            else:
+                os.unlink(old)
+
     # Move away files. Default target is docdir, but others can
     # be set by appending =<new name> to the entry, as in
     # tmpfiles.d=libdir/tmpfiles.d
@@ -40,16 +50,6 @@ def stateless_mangle(d, root, docdir, stateless_mv, stateless_rm, dirwhitelist, 
                 else:
                     os.rename(old, new)
             move(old, new)
-
-    # Remove content that is no longer needed.
-    for entry in stateless_rm:
-        old = os.path.join(root, 'etc', entry)
-        if os.path.exists(old) or os.path.islink(old):
-            bb.note('stateless: removing %s' % old)
-            if os.path.isdir(old) and not os.path.islink(old):
-                shutil.rmtree(old)
-            else:
-                os.unlink(old)
 
     # Remove /etc if all that's left are directories.
     # Some directories are expected to exists (for example,

--- a/meta-ostro/conf/distro/include/stateless.inc
+++ b/meta-ostro/conf/distro/include/stateless.inc
@@ -340,6 +340,18 @@ STATELESS_RM_pn-systemd += "xdg/systemd/user"
 # Managed by connman at runtime.
 STATELESS_RM_pn-systemd += "resolv.conf"
 
+# Remove this because it might confuse our setup
+# depending how components parse/combine their
+# configuration. For example with nsswitch.conf
+# "Clear" patched glibc combines its configuration
+# from defaults and /etc. This happens because tmpfiles
+# copies nsswitch.conf to /etc (and this copy is
+# defined in etc.conf). File has to be deleted
+# with rm because it is not even originally in /etc.
+do_install_append_pn-systemd () {
+    rm ${D}${exec_prefix}/lib/tmpfiles.d/etc.conf
+}
+
 # Only two options are set:
 # net.ipv4.conf.default.rp_filter=1
 # net.ipv4.conf.all.rp_filter=1
@@ -526,7 +538,7 @@ passwd:         files altfiles
 group:          files altfiles
 shadow:         files altfiles
 
-hosts:          files altfiles dns
+hosts:          files altfiles mymachines resolve myhostname
 networks:       files altfiles
 
 protocols:      db files altfiles


### PR DESCRIPTION
Remove tmpfiles etc.conf altogether. This is because tmpfiles 
is confusing the Clear stateless functionality in some cases like 
nsswitch.conf. 

Also change order of rm and mv in stateless.bbclass. As I previously 
claimed this was not the reason for etc.conf not to be removed. However, 
this change might be good anyway,
